### PR TITLE
copying initial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.4"
 
 env:
-  - DJANGO_SPEC=Django=~1.5
+  - DJANGO_SPEC=Django~=1.5
   - DJANGO_SPEC=Django~=1.6
   - DJANGO_SPEC=Django~=1.7
   - DJANGO_SPEC=Django~=1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
+  - "3.4"
 
 env:
-  - DJANGO_SPEC=Django==1.5.5
-  - DJANGO_SPEC=Django==1.6.2
+  - DJANGO_SPEC=Django=~1.5
+  - DJANGO_SPEC=Django~=1.6
+  - DJANGO_SPEC=Django~=1.7
+  - DJANGO_SPEC=Django~=1.8
   - DJANGO_SPEC=https://github.com/django/django/zipball/master\#egg\Django
-
-matrix:
-  exclude:
-    - python: "2.6"
-      env: DJANGO_SPEC=https://github.com/django/django/zipball/master\#egg\Django
 
 install:
   - pip install coveralls --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - DJANGO_SPEC=Django~=1.6
   - DJANGO_SPEC=Django~=1.7
   - DJANGO_SPEC=Django~=1.8
-  - DJANGO_SPEC=https://github.com/django/django/zipball/master\#egg\Django
+  - DJANGO_SPEC=git+https://github.com/django/django.git
 
 install:
   - pip install coveralls --use-mirrors

--- a/README.rst
+++ b/README.rst
@@ -32,3 +32,20 @@ forms and develop more complex abstractions. Rebar includes:
   FormGroup instances for use in unit tests.
 
 Rebar supports Django 1.5 and later on Python 2.6, 2.7, and 3.3.
+
+
+Running Tests
+=============
+
+You can run the tests with ``setup.py``::
+
+  $ python setup.py test
+
+Tox allows you to run the tests against the supported dependency matrix.
+
+::
+
+   $ pip install tox
+   $ tox
+
+Rebar prefers Tox 2.0 or later.

--- a/docs/form-groups.rst
+++ b/docs/form-groups.rst
@@ -65,7 +65,7 @@ form.
 .. doctest::
 
    >>> ContactFormGroup()  # doctest: +ELLIPSIS
-   <rebar.group.FormGroup object at ...>
+   <rebar.group.FormGroup ...>
 
 
 Using Form Groups
@@ -86,9 +86,9 @@ either by index or name.
 
    >>> form_group = ContactFormGroup()
    >>> form_group.contact
-   <ContactForm object at ...>
+   <ContactForm ...>
    >>> form_group.address
-   <AddressForm object at ...>
+   <AddressForm ...>
    >>> form_group[0] == form_group.contact
    True
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -97,7 +97,7 @@ prefix set to the ``__prefix__`` sentinel.
 .. doctest::
 
    >>> formset.empty_form  # doctest: +ELLIPSIS
-   <NameForm object at ...>
+   <NameForm ...>
    >>> formset.empty_form.prefix
    u'form-__prefix__'
 

--- a/src/rebar/dix.py
+++ b/src/rebar/dix.py
@@ -1,0 +1,6 @@
+# Django "Six"
+
+try:
+    from django.forms.util import ErrorList
+except ImportError:
+    from django.forms.utils import ErrorList

--- a/src/rebar/group.py
+++ b/src/rebar/group.py
@@ -70,7 +70,7 @@ class FormGroup(object):
                     auto_id=self.auto_id,
                     error_class=self.error_class,
                     label_suffix=self.label_suffix,
-                    initial=self.initial,
+                    initial=self.initial.copy(),
                 ))
 
             elif issubclass(member_class, BaseInlineFormSet):

--- a/src/rebar/group.py
+++ b/src/rebar/group.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 from django.forms.forms import BaseForm
 from django.forms.formsets import BaseFormSet
 from django.forms.models import BaseInlineFormSet
-from django.forms.util import ErrorList
+from rebar.dix import ErrorList
 
 from rebar.validators import StateValidatorFormMixin
 

--- a/src/rebar/tests/test_groups.py
+++ b/src/rebar/tests/test_groups.py
@@ -312,6 +312,25 @@ class FormGroupInitialTests(TestCase):
             'Joe',
         )
 
+    def test_pass_seperate_initial(self):
+        """
+        This test is related to bug in which the same initial was made
+        available to the __init__ for each subform. Elements of initial that
+        happened to have the same key were being overwritten.
+        """
+        class OtherNameForm(NameForm):
+            def __init__(self, *args, **kwargs):
+                kwargs['initial']['first_name'] = 'Steve'
+
+        fg_class = formgroup_factory(
+            (OtherNameForm,
+             NameForm),
+        )
+
+        formgroup = fg_class()
+
+        self.assertNotEqual(formgroup.name.initial.get('first_name'), 'Steve')
+
     def test_initial_not_passed_to_formgroups(self):
 
         fg_class = formgroup_factory(

--- a/src/rebar/tests/test_groups.py
+++ b/src/rebar/tests/test_groups.py
@@ -2,10 +2,9 @@
 Tests for FormGroups
 """
 
-from django.utils.unittest import TestCase
+from unittest import TestCase
 
 from django.core.exceptions import ValidationError
-from django.forms.util import ErrorList
 from django.forms.formsets import (
     BaseFormSet,
     formset_factory,
@@ -23,6 +22,7 @@ from rebar.tests.helpers import (
     NameForm,
 )
 
+from rebar.dix import ErrorList
 from rebar.group import (
     formgroup_factory,
     FormGroup,

--- a/src/rebar/tests/test_testing.py
+++ b/src/rebar/tests/test_testing.py
@@ -1,5 +1,5 @@
 from django import VERSION
-from django.utils.unittest import TestCase
+from unittest import TestCase
 
 from django.forms.formsets import formset_factory
 

--- a/src/rebar/validators.py
+++ b/src/rebar/validators.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.forms import forms, formsets
-from django.forms.util import ErrorList
+from rebar.dix import ErrorList
 
 
 class StateValidatorFormMixin(object):

--- a/tox.ini
+++ b/tox.ini
@@ -1,88 +1,19 @@
 [tox]
-#    py27-dj14,
-envlist =
-    py26-dj15,
-    py26-dj16,
-    py27-dj15,
-    py27-dj16,
-    py27-dj-master,
-    py33-dj15,
-    py33-dj16,
-    py33-dj-master
+envlist = {py27,py34}-django{15,16,17,18,head}
 
 [testenv]
-deps=
-  Sphinx
+basepython =
+    py27: python2.7
+    py34: python3.4
+
+deps =
+    coverage
+    Sphinx
+    django15: Django~=1.5
+    django16: Django~=1.6
+    django17: Django~=1.7
+    django18: Django~=1.8
+    djangohead: git+https://github.com/django/django.git
+
 commands=
   coverage run --source=rebar setup.py test
-
-[testenv:py33-dj15]
-basepython=python3.3
-deps=
-  coverage
-  Sphinx
-  Django==1.5.5
-
-[testenv:py33-dj16]
-basepython=python3.3
-deps=
-  coverage
-  Sphinx
-  Django==1.6.2
-
-[testenv:py33-dj-master]
-basepython=python3.3
-deps=
-  coverage
-  Sphinx
-  git+https://github.com/django/django.git#egg=Django
-
-[testenv:py27-dj14]
-basepython=python2.7
-deps=
-  coverage
-  Sphinx
-  Django==1.4.10
-
-[testenv:py27-dj15]
-basepython=python2.7
-deps=
-  coverage
-  Sphinx
-  Django==1.5.5
-
-[testenv:py27-dj16]
-basepython=python2.7
-deps=
-  coverage
-  Sphinx
-  Django==1.6.2
-
-[testenv:py27-dj-master]
-basepython=python2.7
-deps=
-  coverage
-  Sphinx
-  git+https://github.com/django/django.git#egg=Django
-
-
-[testenv:py26-dj14]
-basepython=python2.6
-deps=
-  coverage
-  Sphinx
-  Django==1.4.10
-
-[testenv:py26-dj15]
-basepython=python2.6
-deps=
-  coverage
-  Sphinx
-  Django==1.5.5
-
-[testenv:py26-dj16]
-basepython=python2.6
-deps=
-  coverage
-  Sphinx
-  Django==1.6.2


### PR DESCRIPTION
copying `initial` rather than sharing the same `initial` with all sub-forms. This was causing a problem where forms that share the same key in initial were overwriting one another.