### PR TITLE
Try to first import from django.forms.utils to resolve RemovedInDjang…

### DIFF
--- a/src/rebar/dix.py
+++ b/src/rebar/dix.py
@@ -1,6 +1,6 @@
 # Django "Six"
 
 try:
-    from django.forms.util import ErrorList
-except ImportError:
     from django.forms.utils import ErrorList
+except ImportError:
+    from django.forms.util import ErrorList


### PR DESCRIPTION
…o19Warning: The django.forms.util module has been renamed. Use django.forms.utils instead