### PR TITLE
Create an eventbrite vendor version of our release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
   - DJANGO_SPEC=git+https://github.com/django/django.git
 
 install:
-  - pip install coveralls --use-mirrors
-  - pip install --use-mirrors $DJANGO_SPEC
+  - pip install coveralls
+  - pip install $DJANGO_SPEC
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   - DJANGO_SPEC=Django~=1.6
   - DJANGO_SPEC=Django~=1.7
   - DJANGO_SPEC=Django~=1.8
-  - DJANGO_SPEC=git+https://github.com/django/django.git
 
 install:
   - pip install coveralls

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,11 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.3'
+version = '0.4'
 
 
 setup(name='rebar',
-      version=version,
+      version=version + 'eventbrite',
       description="",
       long_description=README + '\n\n' + NEWS,
       classifiers=[


### PR DESCRIPTION
Last release in use is 0.4, which was never updated in the setup.py.